### PR TITLE
Fix missing options passing when encoding tagged values

### DIFF
--- a/cbor.lua
+++ b/cbor.lua
@@ -126,7 +126,7 @@ end
 
 local tagged_mt = {};
 function tagged_mt:__tostring() return ("%d(%s)"):format(self.tag, tostring(self.value)); end
-function tagged_mt:__tocbor() return integer(self.tag, 192) .. encode(self.value); end
+function tagged_mt:__tocbor(opts) return integer(self.tag, 192) .. encode(self.value, opts); end
 
 local function tagged(tag, value)
 	assert(tag >= 0, "bad argument #1 to 'tagged' (positive integer expected)");


### PR DESCRIPTION
`__tocbor` method is called in encoders with two arguments - the value itself and `opts`. The latter was omitted in the declaration of `__tocbor` method for tagged values and `encode` in its body also omitted this argument. This caused encoding of tagged values (including anything contained in them) not respect options originally passed to `encode` since the `opts` argument was `nil` from that point on in the recursion.